### PR TITLE
Append attachments on sending a direct message.

### DIFF
--- a/app.js
+++ b/app.js
@@ -18,7 +18,11 @@ client.on('messageReactionAdd', async (messageReaction, user) => {
   let time = new Date(messageReaction.message.createdTimestamp).toISOString().replace(/T/, ' ').replace(/\..+/, '');
   let info = time + '(UTC)' + ' <@' + messageReaction.message.author.id + '> ' + 'in <#' + messageReaction.message.channel.id + '>';
   let message = '[' + info + '] ' + messageReaction.message.content;
-  user.dmChannel.send(message);
+  let attachments = [];
+  for (const [key, attachment] of messageReaction.message.attachments) {
+    attachments.push(attachment.url);
+  }
+  user.dmChannel.send(message, {files: attachments});
 });
 
 client.login(botToken);


### PR DESCRIPTION
Append attachments (mostly images) of the pin-stamped message onto a direct message.

The evidence is below.

Pins stamped:
![Pins stamped](https://user-images.githubusercontent.com/4381346/40320612-398d540e-5d67-11e8-9f6a-6a9204d8880a.png)

Then DMs are sent with images:
![Result direct messages](https://user-images.githubusercontent.com/4381346/40320636-4bb478d8-5d67-11e8-87c7-45aca59039e9.png)
